### PR TITLE
Fix build of the provided devShell (flake)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
         inherit (self.checks.${system}.pre-commit-check) shellHook;
 
         name = "liskvork";
-        inputsFrom = pkgs.lib.attrsets.attrValues packages;
+        inputsFrom = [self.packages.${system}.liskvork];
         packages = with pkgs; [
           zls
         ];


### PR DESCRIPTION
- Fix: #5 

`zigDefaultFlagsArray` is reported as readonly variable due to the devShells `inputsFrom` having the same derivation included twice (due to the dynamic nature of `attrValues packages`.